### PR TITLE
Refactor imports and update APA stylesheet

### DIFF
--- a/src/sphinx_apa_references/__init__.py
+++ b/src/sphinx_apa_references/__init__.py
@@ -1,12 +1,14 @@
-import sphinxcontrib.bibtex.plugin
 import os
-
 from dataclasses import dataclass, field
-from sphinxcontrib.bibtex.style.referencing import BracketStyle
-from sphinxcontrib.bibtex.style.referencing.author_year import AuthorYearReferenceStyle
-from sphinxcontrib.bibtex.directives import BibliographyDirective
+
+import sphinxcontrib.bibtex.plugin
 from sphinx.application import Sphinx
 from sphinx.util.fileutil import copy_asset_file
+from sphinxcontrib.bibtex.directives import BibliographyDirective
+from sphinxcontrib.bibtex.style.referencing import BracketStyle
+from sphinxcontrib.bibtex.style.referencing.author_year import \
+    AuthorYearReferenceStyle
+
 
 class APABibliographyDirective(BibliographyDirective):
     """Same as BibliographyDirective, but forces style='apa'."""
@@ -18,11 +20,13 @@ class APABibliographyDirective(BibliographyDirective):
         print(nodes[0].children)
         return nodes
 
+
 def bracket_style() -> BracketStyle:
     return BracketStyle(
-        left='(',
-        right=')',
+        left="(",
+        right=")",
     )
+
 
 @dataclass
 class MyReferenceStyle(AuthorYearReferenceStyle):
@@ -32,23 +36,30 @@ class MyReferenceStyle(AuthorYearReferenceStyle):
     bracket_label: BracketStyle = field(default_factory=bracket_style)
     bracket_year: BracketStyle = field(default_factory=bracket_style)
 
+
 def copy_stylesheet(app: Sphinx, exc: None) -> None:
     base_dir = os.path.dirname(__file__)
-    style = os.path.join(base_dir, 'assets', 'apastyle.css')
-    
-    if app.builder.format == 'html' and not exc:
-        static_dir = os.path.join(app.builder.outdir, '_static')
+    style = os.path.join(base_dir, "assets", "apastyle.css")
+
+    if app.builder.format == "html" and not exc:
+        static_dir = os.path.join(app.builder.outdir, "_static")
 
         copy_asset_file(style, static_dir)
 
+
 def override_config(app, config):
     # This runs after the user's conf is read
-    config.bibtex_reference_style = 'author_year_round'  # override or set
+    config.bibtex_reference_style = "author_year_round"  # override or set
+
 
 def setup(app):
     app.setup_extension("sphinxcontrib.bibtex")
-    sphinxcontrib.bibtex.plugin.register_plugin('sphinxcontrib.bibtex.style.referencing','author_year_round', MyReferenceStyle)
-    app.add_directive('bibliography', APABibliographyDirective, override=True)
-    app.connect('build-finished', copy_stylesheet)
-    app.add_css_file('apastyle.css')
-    app.connect('config-inited', override_config)
+    sphinxcontrib.bibtex.plugin.register_plugin(
+        "sphinxcontrib.bibtex.style.referencing",
+        "author_year_round",
+        MyReferenceStyle,
+    )
+    app.add_directive("bibliography", APABibliographyDirective, override=True)
+    app.connect("build-finished", copy_stylesheet)
+    app.add_css_file("apastyle.css")
+    app.connect("config-inited", override_config)

--- a/src/sphinx_apa_references/assets/apastyle.css
+++ b/src/sphinx_apa_references/assets/apastyle.css
@@ -8,3 +8,7 @@ div.citation p {
   padding-left: 0.5in;
   text-indent: -0.5in;
 }
+
+div.citation span.backrefs {
+  float:right;
+}


### PR DESCRIPTION
Reorganized imports in __init__.py for clarity and consistency, and improved formatting. Updated apastyle.css to right-align backreferences in citations for better visual presentation.